### PR TITLE
Use Slang v2025.14.1 that has SPIRV validation fix

### DIFF
--- a/hardware-acceleration/CMakeLists.txt
+++ b/hardware-acceleration/CMakeLists.txt
@@ -65,7 +65,7 @@ function(download_github_release REPO_URL TAG_NAME TARGET_DIR)
 endfunction()
 
 # Download external dependencies
-set(SLANG_VERSION "v2025.14")  # Adjust version as needed
+set(SLANG_VERSION "v2025.14.1")  # Adjust version as needed
 
 set(SLANG_DIR "${CMAKE_BINARY_DIR}/external/slang")
 set(SLANG_RHI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/slang-rhi")

--- a/hardware-acceleration/build.bat
+++ b/hardware-acceleration/build.bat
@@ -43,7 +43,7 @@ if not exist %BUILD_DIR% (
 
 REM Configure the project
 echo Configuring project...
-cmake -B %BUILD_DIR% -G %CMAKE_GENERATOR% -A x64
+cmake -B %BUILD_DIR% -G %CMAKE_GENERATOR% -A x64 -DSLANG_RHI_FETCH_SLANG_VERSION=2025.14.1
 
 if %ERRORLEVEL% neq 0 (
     echo CMake configuration failed!

--- a/hardware-acceleration/build.sh
+++ b/hardware-acceleration/build.sh
@@ -43,7 +43,7 @@ fi
 
 # Configure the project
 echo "Configuring project..."
-cmake -B "$BUILD_DIR" -G "$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Release -DSLANG_RHI_FETCH_SLANG_VERSION=2025.14
+cmake -B "$BUILD_DIR" -G "$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Release -DSLANG_RHI_FETCH_SLANG_VERSION=2025.14.1
 
 # Build the project
 echo "Building project..."


### PR DESCRIPTION
With v2025.14.1, it works well on Windows without SPIRV validation error.