### PR TITLE
Fix CUDA compilation by using cross-platform capability names

### DIFF
--- a/hardware-acceleration/mlp-training/kernels.slang
+++ b/hardware-acceleration/mlp-training/kernels.slang
@@ -6,7 +6,7 @@ import network;
 import adam;
 
 [numthreads(256, 1, 1)]
-[require(spvGroupNonUniformBallot, spvGroupNonUniformArithmetic)]
+[require(subgroup_basic, subgroup_arithmetic)]
 #if __SLANG_APPLE__
 [require(metal)]
 #endif


### PR DESCRIPTION
Changed [require(spvGroupNonUniformBallot, spvGroupNonUniformArithmetic)] to [require(subgroup_basic, subgroup_arithmetic)]

The spvGroupNonUniform* capabilities are SPIR-V specific and only map to _spirv_1_3, which doesn't include CUDA support.

The cross-platform equivalents are:
- subgroup_basic: includes GL_KHR_shader_subgroup_basic | _sm_6_0 | _cuda_sm_7_0 | wgsl | metal
- subgroup_arithmetic: includes GL_KHR_shader_subgroup_arithmetic | _sm_6_0 | _cuda_sm_7_0 | wgsl | metal

These properly support all targets including CUDA through warp intrinsics.

Functions used in this shader:
- WaveIsFirstLane() requires subgroup_basic
- WaveActiveMax() requires subgroup_arithmetic

Fixes shader-slang/slang#8360